### PR TITLE
reset keys after successful callback

### DIFF
--- a/lib/useKeyboardShortcut.js
+++ b/lib/useKeyboardShortcut.js
@@ -11,6 +11,9 @@ const keysReducer = (state, action) => {
     case "set-key-up":
       const keyUpState = { ...state, [action.key]: false };
       return keyUpState;
+    case "reset-keys":
+      const resetState = { ...action.data };
+      return resetState;
     default:
       return state;
   }
@@ -81,7 +84,8 @@ const useKeyboardShortcut = (shortcutKeys, callback, options) => {
 
   useEffect(() => {
     if (!Object.values(keys).filter(value => !value).length) {
-      callback(keys)
+      callback(keys);
+      setKeys({ type: "reset-keys", data: initalKeyMapping });
     } else {
       setKeys({ type: null })
     }


### PR DESCRIPTION
Reset state to initialMapping after a successful callback. else, after one successful  callback, it continues to get triggered on pressing any key in the combination rather than waiting for the entire combination.