### PR TITLE
add useIsMounted hook to fix set state on an unmounted component

### DIFF
--- a/lib/useKeyboardShortcut.js
+++ b/lib/useKeyboardShortcut.js
@@ -1,5 +1,6 @@
 import { useEffect, useCallback, useReducer } from "react";
 import { disabledEventPropagation } from './utils'
+import useIsMounted from 'ismounted';
 
 const blacklistedTargets = ["INPUT", "TEXTAREA"];
 
@@ -35,6 +36,7 @@ const useKeyboardShortcut = (shortcutKeys, callback, options) => {
       "The second parameter to `useKeyboardShortcut` must be a function that will be envoked when the keys are pressed."
     );
 
+  const isMounted = useIsMounted();
   const { overrideSystem } = options || {}
   const initalKeyMapping = shortcutKeys.reduce((currentKeys, key) => {
     currentKeys[key.toLowerCase()] = false;
@@ -46,7 +48,7 @@ const useKeyboardShortcut = (shortcutKeys, callback, options) => {
   const keydownListener = useCallback(
     assignedKey => keydownEvent => {
       const loweredKey = assignedKey.toLowerCase();
-      
+
       if (keydownEvent.repeat) return
       if (blacklistedTargets.includes(keydownEvent.target.tagName)) return;
       if (loweredKey !== keydownEvent.key.toLowerCase()) return;
@@ -57,10 +59,13 @@ const useKeyboardShortcut = (shortcutKeys, callback, options) => {
         disabledEventPropagation(keydownEvent);
       }
 
-      setKeys({ type: "set-key-down", key: loweredKey });
+      if (isMounted.current) {
+        setKeys({ type: "set-key-down", key: loweredKey });
+      }
+
       return false;
     },
-    [keys, overrideSystem]
+    [isMounted, keys, overrideSystem]
   );
 
   const keyupListener = useCallback(
@@ -76,10 +81,13 @@ const useKeyboardShortcut = (shortcutKeys, callback, options) => {
         disabledEventPropagation(keyupEvent);
       }
 
-      setKeys({ type: "set-key-up", key: raisedKey });
+      if (isMounted.current) {
+        setKeys({ type: "set-key-up", key: raisedKey });
+      }
+
       return false;
     },
-    [keys, overrideSystem]
+    [isMounted, keys, overrideSystem]
   );
 
   useEffect(() => {

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "bugs": {
     "url": "https://github.com/arthurtyukayev/use-keyboard-shortcut/issues"
   },
-  "homepage": "https://github.com/arthurtyukayev/use-keyboard-shortcut#readme"
+  "homepage": "https://github.com/arthurtyukayev/use-keyboard-shortcut#readme",
+  "dependencies": {
+    "ismounted": "^0.1.8"
+  }
 }


### PR DESCRIPTION
Fix error `Warning: Can only update a mounted or mounting component. This usually means you called setState, replaceState, or forceUpdate on an unmounted component. This is a no-op.
`