### PR TITLE
Update Types

### DIFF
--- a/lib/useKeyboardShortcut.d.ts
+++ b/lib/useKeyboardShortcut.d.ts
@@ -5,7 +5,7 @@ declare function useKeyboardShortcut(
   shortcutKeys: string[],
   callback: callbackFn,
   options?: {
-    overrideSystem: boolean;
-    ignoreInputFields: boolean;
+    overrideSystem?: boolean;
+    ignoreInputFields?: boolean;
   }
 ): void;


### PR DESCRIPTION
This stops errors of this kind when supplying just one of the option keys

```
TS2345: Argument of type '{ overrideSystem: false; }' is not assignable to parameter of type '{ overrideSystem: boolean; ignoreInputFields: boolean; }'.
```