### PR TITLE
explicitly state any type for flushHeldKeys, silencing - error TS7008…

### DIFF
--- a/lib/useKeyboardShortcut.d.ts
+++ b/lib/useKeyboardShortcut.d.ts
@@ -10,4 +10,4 @@ declare function useKeyboardShortcut(
     ignoreInputFields?: boolean;
     repeatOnHold?: boolean;
   }
-): { flushHeldKeys };
+): { flushHeldKeys: any };


### PR DESCRIPTION
flushHeldKeys is currently implicitly 'any'. 

With noImplicityAny set, TS will throw up an error.

See: https://www.typescriptlang.org/tsconfig#noImplicitAny