### PR TITLE
Bug Fix: Typescript return type

### DIFF
--- a/lib/useKeyboardShortcut.d.ts
+++ b/lib/useKeyboardShortcut.d.ts
@@ -1,7 +1,7 @@
 export default useKeyboardShortcut;
 
 type callbackFn = (shortcutKeys: string[]) => void;
-type flushHeldKeys = () => void;
+type FlushHeldKeysFn = () => void;
 declare function useKeyboardShortcut(
   shortcutKeys: string[],
   callback: callbackFn,
@@ -10,5 +10,4 @@ declare function useKeyboardShortcut(
     ignoreInputFields?: boolean;
     repeatOnHold?: boolean;
   }
-): { flushHeldKeys: flushHeldKeys };
-
+): { flushHeldKeys: FlushHeldKeysFn };


### PR DESCRIPTION
Getting a `tsc` error on the latest version
```
node_modules/use-keyboard-shortcut/lib/useKeyboardShortcut.d.ts:13:6 - error TS7008: Member 'flushHeldKeys' implicitly has an 'any' type.

13 ): { flushHeldKeys };
        ~~~~~~~~~~~~~


Found 1 error in node_modules/use-keyboard-shortcut/lib/useKeyboardShortcut.d.ts:13
```
**Library Version**: `1.1.4`
**Node Version**: `16.13.0`
**Typescript Version**: `4.7.4`